### PR TITLE
Benchmarks in the test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+*.test

--- a/src/zackkitzmiller/gotiny/tiny_test.go
+++ b/src/zackkitzmiller/gotiny/tiny_test.go
@@ -32,7 +32,15 @@ func TestMany(t *testing.T) {
 	}
 }
 
-func BenchmarkTiny(b *testing.B) {
+func BenchmarkTinyTo(b *testing.B) {
+	tiny := getTiny()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tiny.To(i)
+	}
+}
+
+func BenchmarkTinyFrom(b *testing.B) {
 	tiny := getTiny()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/src/zackkitzmiller/gotiny/tiny_test.go
+++ b/src/zackkitzmiller/gotiny/tiny_test.go
@@ -31,3 +31,11 @@ func TestMany(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkTiny(b *testing.B) {
+	tiny := getTiny()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tiny.From(tiny.To(i))
+	}
+}


### PR DESCRIPTION
Just wanted to see what kind of performance was going on. Not too shabby.

```
╰─$ go test -bench .
PASS
BenchmarkTinyTo 10000000          218 ns/op
BenchmarkTinyFrom       5000000        380 ns/op
ok      github.com/jesseobrien/tiny-go/src/zackkitzmiller/gotiny  4.880s
```
